### PR TITLE
chore(dependabot): Add dependabot control file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+	- package-ecosystem: maven
+		directory: /
+		schedule:
+			interval: daily


### PR DESCRIPTION
Motivation:
- trigger dependabot scans at will (pushing edits to this file/changing configuration)
- old (read: current at time of writing) dependabot PRs did "not survive" the "remove `portal-` prefix refactoring" and can no longer find the pom.xml files they triggered on initally. 